### PR TITLE
Set lower version constraint on satysfi-base

### DIFF
--- a/satysfi-azmath.opam
+++ b/satysfi-azmath.opam
@@ -15,7 +15,7 @@ depends: [
   "satysfi" {>= "0.0.6" & < "0.0.7"}
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-dist"
-  "satysfi-base"
+  "satysfi-base" {>= "1.4.0" }
 ]
 build: [ ]
 install: [


### PR DESCRIPTION
`List.split-at` is available at satysfi-base 1.4.0 and later.

This PR backports https://github.com/na4zagin3/satyrographos-repo/pull/450