### PR TITLE
operatorname & operatorname-v

### DIFF
--- a/src/azmath.satyh
+++ b/src/azmath.satyh
@@ -3,6 +3,7 @@
 @import: accent
 @import: equation
 @import: matrices
+@import: operator
 @import: parens
 @import: unicode-math
 

--- a/src/operator.satyh
+++ b/src/operator.satyh
@@ -1,0 +1,19 @@
+% azmath/operator.satyh
+%
+% operatorname や operatorname-v のような、文字列を演算子とする関数を定義するパッケージ．
+
+module AZMathOperator : sig
+  direct \operatorname: [string;] math-cmd
+  direct \operatorname-v: [string;] math-cmd
+end = struct
+  let-math \operatorname str = math-char MathOp str
+  let-math \operatorname-v str =
+    let op = math-char MathOp str in
+      math-pull-in-scripts MathOp MathOp (fun sub upper -> (
+        match (sub, upper) with
+        | (None    , None   ) -> op
+        | (Some(s) , None   ) -> math-lower op s
+        | (None    , Some(u)) -> math-upper op u
+        | (Some(s) , Some(u)) -> math-upper (math-lower op s) u
+      ))
+end


### PR DESCRIPTION
**Command/function names you want (not necessarily adopted as a command/function name):**
* ``\operatorname!(`rot`)_{math}^{math}``
* ``\operatorname-v!(`ope`)_{math}^{math}``

**Describe how you want the command/function to work.**
Embedding strings as operators in formulas.

**Can other typesetting system (e.g. LaTeX) do the same thing? If so, provide a method to realize it.**
* `\operatorname{rot}` in LaTeX
* `\operatorname*{ope}` in LaTeX